### PR TITLE
Add arm64 build

### DIFF
--- a/.github/workflows/push_latest.yml
+++ b/.github/workflows/push_latest.yml
@@ -24,6 +24,9 @@ jobs:
 
         echo "Found Micromamba version that is not released on docker: ${LATEST_VERSION}"
         echo "::set-output name=latest_version::${LATEST_VERSION}"
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+      if: steps.check_version.outputs.latest_version != 'no_version_found'
     - name: Login to DockerHub
       uses: docker/login-action@v1
       with:
@@ -34,6 +37,7 @@ jobs:
       id: docker_build
       uses: docker/build-push-action@v2.2.2
       with:
+        platforms: linux/amd64,linux/arm64
         push: true
         build-args: |
           VERSION=${{ steps.check_version.outputs.latest_version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,16 @@ ARG BASE_IMAGE=debian:buster-slim
 
 # Mutli-stage build to keep final image small. Otherwise end up with
 # curl and openssl installed
-FROM debian:buster-slim AS stage1
+FROM --platform=$BUILDPLATFORM debian:buster-slim AS stage1
 ARG VERSION=0.11.3
 RUN apt-get update && apt-get install -y \
     bzip2 \
     ca-certificates \
     curl \
     && rm -rf /var/lib/{apt,dpkg,cache,log}
-RUN curl -L https://micromamba.snakepit.net/api/micromamba/linux-64/$VERSION | \
+ARG TARGETARCH
+RUN [ $TARGETARCH = 'arm64' ] && export ARCH='aarch64' || export ARCH='64' && \
+    curl -L https://micromamba.snakepit.net/api/micromamba/linux-$ARCH/$VERSION | \
     tar -xj -C /tmp bin/micromamba
 
 FROM $BASE_IMAGE

--- a/check_version.py
+++ b/check_version.py
@@ -5,7 +5,7 @@ import semver
 def to_version(s):
     return semver.VersionInfo.parse(s)
 
-
+platforms = ["linux-64", "linux-aarch64"]
 anaconda_api_url = "https://api.anaconda.org/release/conda-forge/micromamba/latest"
 dockerhub_api_url = "https://hub.docker.com/v2/repositories/mambaorg/micromamba/tags/?page_size=25&page=1&ordering=last_updated"
 
@@ -14,10 +14,15 @@ dh_res = requests.get(dockerhub_api_url)
 
 result = ac_res.json()
 
+latest_version = None
 for dist in result["distributions"]:
-    if dist["attrs"]["subdir"] == "linux-64":
-        latest_version = to_version(dist["version"])
-        break
+    if dist["attrs"]["subdir"] in platforms:
+        platform_version = to_version(dist["version"])
+        if latest_version is None:
+            latest_version = platform_version
+        elif platform_version != latest_version:
+            print("no_version_found")
+            exit(0)
 
 dh_result = dh_res.json()
 docker_versions = []


### PR DESCRIPTION
solves #6 

It uses the recommended way for [building multi-platform images](https://github.com/docker/build-push-action/blob/master/docs/advanced/multi-platform.md) with [buildx](https://docs.docker.com/buildx/working-with-buildx/).

I have fully tested it (see the main branch of my fork and my [Docker Hub repo](https://hub.docker.com/repository/docker/wietsedv/micromamba/tags)) and it works perfectly.