### PR TITLE
Fix #47 where image fails to run on arm platforms

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN [ $TARGETARCH = 'amd64' ] && export ARCH='64'; \
     curl -L https://micromamba.snakepit.net/api/micromamba/linux-$ARCH/$VERSION | \
     tar -xj -C /tmp bin/micromamba
 
-FROM --platform=$BUILDPLATFORM $BASE_IMAGE
+FROM $BASE_IMAGE
 
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
 ENV ENV_NAME="base"


### PR DESCRIPTION
I've tested this locally on my M1, I'm currently unable to push the build images to my docker to inspect them but the build process shows that the images are now correctly rebuild for each architecture. Perviously the amd64 image was build using cached layer from arm64 build on M1.  See the output of the build command

```
docker buildx build --platform linux/amd64,linux/arm64 . -t test                                                                                                                                                                                                                                                                      main
WARN[0000] No output specified for docker-container driver. Build result will only remain in the build cache. To push result image into registry use --push or to load image into docker use --load
[+] Building 65.7s (20/20) FINISHED
 => [internal] booting buildkit                                                                                                                                                                                                                                                                                                                                       31.7s
 => => pulling image moby/buildkit:buildx-stable-1                                                                                                                                                                                                                                                                                                                    31.1s
 => => creating container buildx_buildkit_dreamy_shaw0                                                                                                                                                                                                                                                                                                                 0.6s
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                                                                                                                                   0.0s
 => => transferring dockerfile: 1.75kB                                                                                                                                                                                                                                                                                                                                 0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                                                                                                                                                      0.0s
 => => transferring context: 2B                                                                                                                                                                                                                                                                                                                                        0.0s
 => [linux/arm64 internal] load metadata for docker.io/library/debian:bullseye-slim                                                                                                                                                                                                                                                                                    2.8s
 => [auth] library/debian:pull token for registry-1.docker.io                                                                                                                                                                                                                                                                                                          0.0s
 => [internal] load build context                                                                                                                                                                                                                                                                                                                                      0.0s
 => => transferring context: 582B                                                                                                                                                                                                                                                                                                                                      0.0s
 => [linux/arm64 stage1 1/3] FROM docker.io/library/debian:bullseye-slim@sha256:dddc0f5f01db7ca3599fd8cf9821ffc4d09ec9d7d15e49019e73228ac1eee7f9                                                                                                                                                                                                                      18.1s
 => => resolve docker.io/library/debian:bullseye-slim@sha256:dddc0f5f01db7ca3599fd8cf9821ffc4d09ec9d7d15e49019e73228ac1eee7f9                                                                                                                                                                                                                                          0.0s
 => => sha256:a9eb63951c1c2ee8efcc12b696928fee3741a2d4eae76f2da3e161a5d90548bf 30.04MB / 30.04MB                                                                                                                                                                                                                                                                      17.6s
 => => extracting sha256:a9eb63951c1c2ee8efcc12b696928fee3741a2d4eae76f2da3e161a5d90548bf                                                                                                                                                                                                                                                                              0.6s
 => [linux/arm64 stage1 2/3] RUN apt-get update && apt-get install -y     bzip2     ca-certificates     curl     && rm -rf /var/lib/{apt,dpkg,cache,log}                                                                                                                                                                                                               6.3s
 => [linux/arm64 stage1 3/3] RUN [ amd64 = 'amd64' ] && export ARCH='64';     [ amd64 = 'arm64' ] && export ARCH='aarch64';     [ amd64 = 'ppc64le' ] && export ARCH='ppc64le';     curl -L https://micromamba.snakepit.net/api/micromamba/linux-$ARCH/0.15.3 |     tar -xj -C /tmp bin/micromamba                                                                     6.1s
 => [linux/arm64 stage1 3/3] RUN [ arm64 = 'amd64' ] && export ARCH='64';     [ arm64 = 'arm64' ] && export ARCH='aarch64';     [ arm64 = 'ppc64le' ] && export ARCH='ppc64le';     curl -L https://micromamba.snakepit.net/api/micromamba/linux-$ARCH/0.15.3 |     tar -xj -C /tmp bin/micromamba                                                                     4.9s
 => [linux/arm64 stage-1 2/6] COPY --from=stage1 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt                                                                                                                                                                                                                                                 0.0s
 => [linux/arm64 stage-1 3/6] COPY --from=stage1 /tmp/bin/micromamba /bin/micromamba                                                                                                                                                                                                                                                                                   0.0s
 => [linux/arm64 stage-1 4/6] COPY entrypoint.sh /bin/entrypoint.sh                                                                                                                                                                                                                                                                                                    0.0s
 => [linux/arm64 stage-1 5/6] RUN useradd -ms /bin/bash micromamba &&     mkdir -p "/opt/conda" &&     chmod -R a+rwx "/opt/conda" "/home" &&     export ENV_NAME="base"                                                                                                                                                                                               0.1s
 => [linux/arm64 stage-1 6/6] WORKDIR /tmp                                                                                                                                                                                                                                                                                                                             0.0s
 => CACHED [linux/arm64 stage-1 2/6] COPY --from=stage1 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt                                                                                                                                                                                                                                          0.0s
 => [linux/arm64 stage-1 3/6] COPY --from=stage1 /tmp/bin/micromamba /bin/micromamba                                                                                                                                                                                                                                                                                   0.0s
 => [linux/arm64 stage-1 4/6] COPY entrypoint.sh /bin/entrypoint.sh                                                                                                                                                                                                                                                                                                    0.0s
 => [linux/arm64 stage-1 5/6] RUN useradd -ms /bin/bash micromamba &&     mkdir -p "/opt/conda" &&     chmod -R a+rwx "/opt/conda" "/home" &&     export ENV_NAME="base"                                                                                                                                                                                               0.1s
 => [linux/arm64 stage-1 6/6] WORKDIR /tmp
```
Without any changes on m1 the build process is reusing the `arm64` image to create `amd64`, see the line marked by buildx as "CACHED" 

Once I've removed the `--platform` from the second `FROM` it seems to properly build both images (the arm one was cached)
```
docker buildx build --platform linux/amd64,linux/arm64 . -t test                                                                                                                                                                                                                                                            
WARN[0000] No output specified for docker-container driver. Build result will only remain in the build cache. To push result image into registry use --push or to load image into docker use --load
[+] Building 12.0s (21/21) FINISHED
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                                                                                                                                   0.0s
 => => transferring dockerfile: 1.72kB                                                                                                                                                                                                                                                                                                                                 0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                                                                                                                                                      0.0s
 => => transferring context: 2B                                                                                                                                                                                                                                                                                                                                        0.0s
 => [linux/arm64 internal] load metadata for docker.io/library/debian:bullseye-slim                                                                                                                                                                                                                                                                                    1.7s
 => [linux/amd64 internal] load metadata for docker.io/library/debian:bullseye-slim                                                                                                                                                                                                                                                                                    2.3s
 => [auth] library/debian:pull token for registry-1.docker.io                                                                                                                                                                                                                                                                                                          0.0s
 => [linux/arm64 stage1 1/3] FROM docker.io/library/debian:bullseye-slim@sha256:dddc0f5f01db7ca3599fd8cf9821ffc4d09ec9d7d15e49019e73228ac1eee7f9                                                                                                                                                                                                                       0.0s
 => => resolve docker.io/library/debian:bullseye-slim@sha256:dddc0f5f01db7ca3599fd8cf9821ffc4d09ec9d7d15e49019e73228ac1eee7f9                                                                                                                                                                                                                                          0.0s
 => [linux/amd64 stage-1 1/6] FROM docker.io/library/debian:bullseye-slim@sha256:dddc0f5f01db7ca3599fd8cf9821ffc4d09ec9d7d15e49019e73228ac1eee7f9                                                                                                                                                                                                                      9.2s
 => => resolve docker.io/library/debian:bullseye-slim@sha256:dddc0f5f01db7ca3599fd8cf9821ffc4d09ec9d7d15e49019e73228ac1eee7f9                                                                                                                                                                                                                                          0.0s
 => => sha256:7d63c13d9b9b6ec5f05a2b07daadacaa9c610d01102a662ae9b1d082105f1ffa 31.36MB / 31.36MB                                                                                                                                                                                                                                                                       8.5s
 => => extracting sha256:7d63c13d9b9b6ec5f05a2b07daadacaa9c610d01102a662ae9b1d082105f1ffa                                                                                                                                                                                                                                                                              0.6s
 => [internal] load build context                                                                                                                                                                                                                                                                                                                                      0.0s
 => => transferring context: 35B                                                                                                                                                                                                                                                                                                                                       0.0s
 => CACHED [linux/arm64 stage1 2/3] RUN apt-get update && apt-get install -y     bzip2     ca-certificates     curl     && rm -rf /var/lib/{apt,dpkg,cache,log}                                                                                                                                                                                                        0.0s
 => CACHED [linux/arm64 stage1 3/3] RUN [ amd64 = 'amd64' ] && export ARCH='64';     [ amd64 = 'arm64' ] && export ARCH='aarch64';     [ amd64 = 'ppc64le' ] && export ARCH='ppc64le';     curl -L https://micromamba.snakepit.net/api/micromamba/linux-$ARCH/0.15.3 |     tar -xj -C /tmp bin/micromamba                                                              0.0s
 => CACHED [linux/arm64 stage1 3/3] RUN [ arm64 = 'amd64' ] && export ARCH='64';     [ arm64 = 'arm64' ] && export ARCH='aarch64';     [ arm64 = 'ppc64le' ] && export ARCH='ppc64le';     curl -L https://micromamba.snakepit.net/api/micromamba/linux-$ARCH/0.15.3 |     tar -xj -C /tmp bin/micromamba                                                              0.0s
 => CACHED [linux/arm64 stage-1 2/6] COPY --from=stage1 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt                                                                                                                                                                                                                                          0.0s
 => CACHED [linux/arm64 stage-1 3/6] COPY --from=stage1 /tmp/bin/micromamba /bin/micromamba                                                                                                                                                                                                                                                                            0.0s
 => CACHED [linux/arm64 stage-1 4/6] COPY entrypoint.sh /bin/entrypoint.sh                                                                                                                                                                                                                                                                                             0.0s
 => CACHED [linux/arm64 stage-1 5/6] RUN useradd -ms /bin/bash micromamba &&     mkdir -p "/opt/conda" &&     chmod -R a+rwx "/opt/conda" "/home" &&     export ENV_NAME="base"                                                                                                                                                                                        0.0s
 => CACHED [linux/arm64 stage-1 6/6] WORKDIR /tmp                                                                                                                                                                                                                                                                                                                      0.0s
 => [linux/amd64 stage-1 2/6] COPY --from=stage1 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt                                                                                                                                                                                                                                                 0.1s
 => [linux/amd64 stage-1 3/6] COPY --from=stage1 /tmp/bin/micromamba /bin/micromamba                                                                                                                                                                                                                                                                                   0.0s
 => [linux/amd64 stage-1 4/6] COPY entrypoint.sh /bin/entrypoint.sh                                                                                                                                                                                                                                                                                                    0.0s
 => [linux/amd64 stage-1 5/6] RUN useradd -ms /bin/bash micromamba &&     mkdir -p "/opt/conda" &&     chmod -R a+rwx "/opt/conda" "/home" &&     export ENV_NAME="base"                                                                                                                                                                                               0.2s
 => [linux/amd64 stage-1 6/6] WORKDIR /tmp v
```