### PR TITLE
More robust activation in _entrypoint.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,12 +39,13 @@ RUN "$MAMBA_EXE" shell init -p "$MAMBA_ROOT_PREFIX" -s bash > /dev/null && \
 WORKDIR /tmp
 
 # Script which launches commands passed to "docker run"
-COPY _entrypoint.sh /bin/_entrypoint.sh
-ENTRYPOINT ["/bin/_entrypoint.sh"]
+COPY _entrypoint.sh /usr/local/bin/_entrypoint.sh
+COPY _activate_current_env.sh /usr/local/bin/_activate_current_env.sh
+ENTRYPOINT ["/usr/local/bin/_entrypoint.sh"]
 
 # Default command for "docker run"
 CMD ["/bin/bash"]
 
 # Script which launches RUN commands in Dockerfile
-COPY _dockerfile_shell.sh /bin/_dockerfile_shell.sh
-SHELL ["/bin/_dockerfile_shell.sh"]
+COPY _dockerfile_shell.sh /usr/local/bin/_dockerfile_shell.sh
+SHELL ["/usr/local/bin/_dockerfile_shell.sh"]

--- a/_activate_current_env.sh
+++ b/_activate_current_env.sh
@@ -1,0 +1,9 @@
+# This script should never be called directly, only sourced:
+
+#     source _activate_current_env.sh
+
+eval "$("${MAMBA_EXE}" shell hook --shell=bash)"
+# For robustness, try all possible activate commands.
+conda activate "${ENV_NAME}" 2>/dev/null \
+  || mamba activate "${ENV_NAME}" 2>/dev/null \
+  || micromamba activate "${ENV_NAME}"

--- a/_dockerfile_shell.sh
+++ b/_dockerfile_shell.sh
@@ -4,11 +4,7 @@ set -ef -o pipefail
 
 # Activate the environment if $MAMBA_DOCKERFILE_ACTIVATE=1
 if [[ "${MAMBA_DOCKERFILE_ACTIVATE}" == "1" ]]; then
-  eval "$(/bin/micromamba shell hook --shell=bash)"
-  # For robustness, try all possible activate commands.
-  conda activate "${ENV_NAME}" 2>/dev/null \
-  || mamba activate "${ENV_NAME}" 2>/dev/null \
-  || micromamba activate "${ENV_NAME}"
+  source _activate_current_env.sh
 fi
 
 exec bash -o pipefail -c "$@"

--- a/_entrypoint.sh
+++ b/_entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -ef -o pipefail
 
@@ -9,6 +9,6 @@ if [[ ! -v USER && $(id -u) -gt 0 ]]; then
   export HOME="/home/$USER"
 fi
 
-eval "$(/bin/micromamba shell hook -s bash)"
-micromamba activate "$ENV_NAME"
+source _activate_current_env.sh
+
 exec "$@"

--- a/test/mamba-1322-workaround.Dockerfile
+++ b/test/mamba-1322-workaround.Dockerfile
@@ -1,0 +1,4 @@
+FROM micromamba:test
+RUN mkdir -p /opt/conda/etc/profile.d/ \
+  # Define a do-nothing mamba function as a placeholder
+  && echo "mamba() { :; }" > /opt/conda/etc/profile.d/mamba.sh

--- a/test/mamba-1322-workaround.bats
+++ b/test/mamba-1322-workaround.bats
@@ -1,0 +1,25 @@
+setup_file() {
+    load 'test_helper/common-setup'
+    _common_setup
+    docker build --quiet \
+                 --tag=micromamba:test \
+		 --file=${PROJECT_ROOT}/Dockerfile \
+		 "$PROJECT_ROOT" > /dev/null
+    docker build --quiet \
+                 --tag=mamba-1322-workaround \
+		 --file=${PROJECT_ROOT}/test/mamba-1322-workaround.Dockerfile \
+		 "${PROJECT_ROOT}/test" > /dev/null
+}
+
+setup() {
+    load 'test_helper/common-setup'
+    _common_setup
+}
+
+# Test the workaround for <https://github.com/mamba-org/mamba/issues/1322> as described
+# in <https://github.com/mamba-org/micromamba-docker/issues/57>.
+
+@test "docker run --rm  mamba-1322-workaround echo squeamish ossifrage" {
+    run docker run --rm  mamba-1322-workaround echo squeamish ossifrage
+    assert_output "squeamish ossifrage"
+}


### PR DESCRIPTION
Works around #57, https://github.com/mamba-org/mamba/issues/1322

Does activation in a new script `_activate_current_env.sh`

Moves the scripts from `/bin/` to `/usr/local/bin/`

Changes shebang in `_entrypoint.sh`