### PR TITLE
Eliminate redundant variable export

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,6 @@ COPY --from=stage1 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certific
 COPY --from=stage1 /tmp/bin/micromamba "$MAMBA_EXE"
 
 RUN useradd -ms /bin/bash micromamba && \
-    export ENV_NAME="$ENV_NAME" && \
     mkdir -p "$MAMBA_ROOT_PREFIX" && \
     "$MAMBA_EXE" shell init -p "$MAMBA_ROOT_PREFIX" -s bash > /dev/null && \
     chmod -R a+rwx "$MAMBA_ROOT_PREFIX" "/home" && \


### PR DESCRIPTION
This can't be doing anything, can it? It's already in the environment.

But `bash` is weird... so maybe it does something.

In case it is doing something, maybe we should add an explanatory comment?

I'm looking forward to seeing whether or not the tests pass... :eyes: