### PR TITLE
Declare DOCKER_BUILDKIT=1 in test.sh

### DIFF
--- a/.github/workflows/push_latest.yml
+++ b/.github/workflows/push_latest.yml
@@ -29,8 +29,6 @@ jobs:
         echo "::set-output name=latest_version::${LATEST_VERSION}"
     - name: Run tests
       run: ./test.sh
-      env:
-        DOCKER_BUILDKIT: 1
       if: steps.check_version.outputs.latest_version != 'no_version_found'
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,5 +17,3 @@ jobs:
           submodules: recursive
       - name: Run tests
         run: ./test.sh
-        env:
-          DOCKER_BUILDKIT: 1

--- a/test.sh
+++ b/test.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -eu -o pipefail
 
+export DOCKER_BUILDKIT=1
+
 FLAGS=
 if which parallel > /dev/null; then
   if [[ $(uname -s) == "Darwin" ]]; then


### PR DESCRIPTION
When I run `test.sh` locally, it fails because I don't set `DOCKER_BUILDKIT=1`. Since non-buildkit builds aren't supported, we should just declare it in `test.sh` so it's set properly everywhere.