### PR TITLE
Tag Docker images with short SHA

### DIFF
--- a/.github/workflows/push_latest.yml
+++ b/.github/workflows/push_latest.yml
@@ -48,6 +48,7 @@ jobs:
         build-args: |
           VERSION=${{ steps.check_version.outputs.latest_version }}
         tags: |
+          mambaorg/micromamba:${GITHUB_SHA::7}
           mambaorg/micromamba:${{ steps.check_version.outputs.latest_version }}
           mambaorg/micromamba:latest
       if: steps.check_version.outputs.latest_version != 'no_version_found'

--- a/.github/workflows/push_latest.yml
+++ b/.github/workflows/push_latest.yml
@@ -29,16 +29,16 @@ jobs:
         echo "::set-output name=latest_version::${LATEST_VERSION}"
     - name: Run tests
       run: ./test.sh
-      if: steps.check_version.outputs.latest_version != 'no_version_found'
+      if: (steps.check_version.outputs.latest_version != 'no_version_found') || (github.event_name == 'workflow_dispatch')
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
-      if: steps.check_version.outputs.latest_version != 'no_version_found'
+      if: (steps.check_version.outputs.latest_version != 'no_version_found') || (github.event_name == 'workflow_dispatch')
     - name: Login to DockerHub
       uses: docker/login-action@v1
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
-      if: steps.check_version.outputs.latest_version != 'no_version_found'
+      if: (steps.check_version.outputs.latest_version != 'no_version_found') || (github.event_name == 'workflow_dispatch')
     - name: Build and push Docker images
       id: docker_build
       uses: docker/build-push-action@v2.2.2
@@ -51,7 +51,7 @@ jobs:
           mambaorg/micromamba:${GITHUB_SHA::7}
           mambaorg/micromamba:${{ steps.check_version.outputs.latest_version }}
           mambaorg/micromamba:latest
-      if: steps.check_version.outputs.latest_version != 'no_version_found'
+      if: (steps.check_version.outputs.latest_version != 'no_version_found') || (github.event_name == 'workflow_dispatch')
     - name: Image digest
       run: echo ${{ steps.docker_build.outputs.digest }}
-      if: steps.check_version.outputs.latest_version != 'no_version_found'
+      if: (steps.check_version.outputs.latest_version != 'no_version_found') || (github.event_name == 'workflow_dispatch')

--- a/.github/workflows/push_latest.yml
+++ b/.github/workflows/push_latest.yml
@@ -48,7 +48,7 @@ jobs:
         build-args: |
           VERSION=${{ steps.check_version.outputs.latest_version }}
         tags: |
-          mambaorg/micromamba:${GITHUB_SHA::7}
+          mambaorg/micromamba:git-${GITHUB_SHA::7}
           mambaorg/micromamba:${{ steps.check_version.outputs.latest_version }}
           mambaorg/micromamba:latest
       if: (steps.check_version.outputs.latest_version != 'no_version_found') || (github.event_name == 'workflow_dispatch')


### PR DESCRIPTION
This ensures that images will not be lost if we publish a new image between micromamba releases.

Based on https://stackoverflow.com/a/66811588

I don't know how to test this short of seeing what happens on the next release. (I'm not so experienced with GitHub Actions.)