### PR TITLE
Modify /etc/skel/.bashrc instead of user's .bashrc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,14 +26,13 @@ ENV MAMBA_EXE="/bin/micromamba"
 COPY --from=stage1 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=stage1 /tmp/bin/micromamba "$MAMBA_EXE"
 
-RUN useradd -ms /bin/bash micromamba && \
+RUN echo "source _activate_current_env.sh" >> ~/.bashrc && \
+    echo "source _activate_current_env.sh" >> /etc/skel/.bashrc && \
+    useradd -ms /bin/bash micromamba && \
     mkdir -p "$MAMBA_ROOT_PREFIX" && \
-    chmod -R a+rwx "$MAMBA_ROOT_PREFIX" "/home" && \
-    echo "source _activate_current_env.sh" >> ~/.bashrc
+    chmod -R a+rwx "$MAMBA_ROOT_PREFIX" "/home"
 
 USER micromamba
-RUN echo "source _activate_current_env.sh" >> ~/.bashrc
-
 WORKDIR /tmp
 
 # Script which launches commands passed to "docker run"

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,8 @@ ENV MAMBA_EXE="/bin/micromamba"
 COPY --from=stage1 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=stage1 /tmp/bin/micromamba "$MAMBA_EXE"
 
-RUN echo "source _activate_current_env.sh" >> ~/.bashrc && \
-    echo "source _activate_current_env.sh" >> /etc/skel/.bashrc && \
+RUN echo "source /usr/local/bin/_activate_current_env.sh" >> ~/.bashrc && \
+    echo "source /usr/local/bin/_activate_current_env.sh" >> /etc/skel/.bashrc && \
     useradd -ms /bin/bash micromamba && \
     mkdir -p "$MAMBA_ROOT_PREFIX" && \
     chmod -R a+rwx "$MAMBA_ROOT_PREFIX" "/home"

--- a/test/new-user.Dockerfile
+++ b/test/new-user.Dockerfile
@@ -1,0 +1,10 @@
+FROM micromamba:test
+RUN micromamba install -y -n base -c conda-forge \
+       python=3.9.1  && \
+    micromamba clean --all --yes
+
+USER root
+
+RUN useradd -ms /bin/bash testuser
+
+USER testuser

--- a/test/new-user.bats
+++ b/test/new-user.bats
@@ -1,0 +1,45 @@
+setup_file() {
+    load 'test_helper/common-setup'
+    _common_setup
+
+    if [ -z "${MICROMAMBA_VERSION}" ]; then
+      export MICROMAMBA_VERSION="$(./check_version.py 2> /dev/null | cut -f1 -d,)"
+    fi
+
+    # only used for building the micromamba image, not derived images
+    MICROMAMBA_FLAGS="--build-arg VERSION=${MICROMAMBA_VERSION}"
+
+    docker build $MICROMAMBA_FLAGS \
+                 --quiet \
+                 --tag=micromamba:test \
+		 --file=${PROJECT_ROOT}/Dockerfile \
+		 "$PROJECT_ROOT" > /dev/null
+    docker build --quiet \
+                 --tag=new-user \
+		 --file=${PROJECT_ROOT}/test/new-user.Dockerfile \
+		 "${PROJECT_ROOT}/test" > /dev/null
+}
+
+setup() {
+    load 'test_helper/common-setup'
+    _common_setup
+}
+
+
+# Simulate TTY input for the docker run command
+# https://stackoverflow.com/a/20401674
+faketty() {
+    script --return --quiet --flush --command "$(printf "%q " "$@")" /dev/null
+}
+
+# Test .bashrc activation for a fresh user by disabling the entrypoint script.
+@test "'docker run --rm -it --entrypoint=/bin/bash new-user' with 'python --version; exit'" {
+    input="python --version; exit"
+    echo -e $input | faketty \
+        docker run --rm -it --entrypoint=/bin/bash new-user
+
+    # Make sure that a similar command actually fails
+    input="xyz --version; exit"
+    ! echo -e $input | faketty \
+        docker run --rm -it --entrypoint=/bin/bash new-user
+}

--- a/test/new-user.bats
+++ b/test/new-user.bats
@@ -1,19 +1,6 @@
 setup_file() {
     load 'test_helper/common-setup'
     _common_setup
-
-    if [ -z "${MICROMAMBA_VERSION}" ]; then
-      export MICROMAMBA_VERSION="$(./check_version.py 2> /dev/null | cut -f1 -d,)"
-    fi
-
-    # only used for building the micromamba image, not derived images
-    MICROMAMBA_FLAGS="--build-arg VERSION=${MICROMAMBA_VERSION}"
-
-    docker build $MICROMAMBA_FLAGS \
-                 --quiet \
-                 --tag=micromamba:test \
-		 --file=${PROJECT_ROOT}/Dockerfile \
-		 "$PROJECT_ROOT" > /dev/null
     docker build --quiet \
                  --tag=new-user \
 		 --file=${PROJECT_ROOT}/test/new-user.Dockerfile \
@@ -23,13 +10,6 @@ setup_file() {
 setup() {
     load 'test_helper/common-setup'
     _common_setup
-}
-
-
-# Simulate TTY input for the docker run command
-# https://stackoverflow.com/a/20401674
-faketty() {
-    script --return --quiet --flush --command "$(printf "%q " "$@")" /dev/null
 }
 
 # Test .bashrc activation for a fresh user by disabling the entrypoint script.


### PR DESCRIPTION
This way the `.bashrc` template is modified so that new users get it automatically.