### PR TITLE
Fix activation error when mamba installed

### DIFF
--- a/_activate_current_env.sh
+++ b/_activate_current_env.sh
@@ -6,7 +6,11 @@ if [[ "${MAMBA_SKIP_ACTIVATE}" == "1" ]]; then
   return
 fi
 
-eval "$("${MAMBA_EXE}" shell hook --shell=bash)"
+# Initialize the current shell
+eval "$(MAMBA_ROOT_PREFIX=/_invalid "${MAMBA_EXE}" shell hook --shell=bash)"
+# Note: adding "MAMBA_ROOT_PREFIX=/_invalid" is an ugly temporary workaround
+# for <https://github.com/mamba-org/mamba/issues/1322>.
+
 # For robustness, try all possible activate commands.
 conda activate "${ENV_NAME}" 2>/dev/null \
   || mamba activate "${ENV_NAME}" 2>/dev/null \

--- a/test/mamba-1322-workaround.Dockerfile
+++ b/test/mamba-1322-workaround.Dockerfile
@@ -1,4 +1,4 @@
 FROM micromamba:test
 RUN mkdir -p /opt/conda/etc/profile.d/ \
   # Define a do-nothing mamba function as a placeholder
-  && echo "mamba() { :; }" > /opt/conda/etc/profile.d/mamba.sh
+  && echo "mamba() { __conda_activate activate base; }" > /opt/conda/etc/profile.d/mamba.sh


### PR DESCRIPTION
Unfortunately #69 did not solve #57. The test I wrote to fake the `mamba()` shell function was too forgiving.

Until this is fixed upstream in https://github.com/mamba-org/mamba/issues/1322, it seems that an ugly workaround is necessary... the shell is properly initialized for micromamba as long as `mamba.sh` remains hidden during initialization. For initialization, `micromamba` searches for `mamba.sh` under `$MAMBA_ROOT_PREFIX/etc/profile.d/mamba.sh`, but doesn't otherwise make use of `MAMBA_ROOT_PREFIX`. Thus I can achieve proper initialization by temporarily setting an invalid `MAMBA_ROOT_PREFIX`.