### PR TITLE
Adds support for custom user id/gid

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ ARG BASE_IMAGE=debian:bullseye-slim
 
 # Mutli-stage build to keep final image small. Otherwise end up with
 # curl and openssl installed
-FROM --platform=$BUILDPLATFORM $BASE_IMAGE AS stage1
+#FROM --platform=$BUILDPLATFORM $BASE_IMAGE AS stage1
+FROM $BASE_IMAGE AS stage1
 ARG VERSION=0.21.0
 RUN apt-get update && apt-get install -y \
     bzip2 \
@@ -27,11 +28,14 @@ COPY --from=stage1 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certific
 COPY --from=stage1 /tmp/bin/micromamba "$MAMBA_EXE"
 
 ARG MAMBA_USER=mambauser
+ARG MAMBA_USER_ID=1000
+ARG MAMBA_USER_GID=1000
 ENV MAMBA_USER=$MAMBA_USER
 
 RUN echo "source /usr/local/bin/_activate_current_env.sh" >> ~/.bashrc && \
     echo "source /usr/local/bin/_activate_current_env.sh" >> /etc/skel/.bashrc && \
-    useradd -ms /bin/bash "$MAMBA_USER" && \
+    useradd -u "${MAMBA_USER_ID}" -ms /bin/bash -U "${MAMBA_USER}" && \
+    groupmod -g "${MAMBA_USER_GID}" "${MAMBA_USER}" && \
     echo "${MAMBA_USER}" > "/etc/arg_mamba_user" && \
     mkdir -p "$MAMBA_ROOT_PREFIX" && \
     chmod -R a+rwx "$MAMBA_ROOT_PREFIX" "/home" "/etc/arg_mamba_user" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG BASE_IMAGE=debian:bullseye-slim
 
 # Mutli-stage build to keep final image small. Otherwise end up with
 # curl and openssl installed
-FROM --platform=$BUILDPLATFORM $BASE_IMAGE AS stage1
+FROM $BASE_IMAGE AS stage1
 ARG VERSION=0.21.2
 RUN apt-get update && apt-get install -y \
     bzip2 \
@@ -33,8 +33,8 @@ ENV MAMBA_USER=$MAMBA_USER
 
 RUN echo "source /usr/local/bin/_activate_current_env.sh" >> ~/.bashrc && \
     echo "source /usr/local/bin/_activate_current_env.sh" >> /etc/skel/.bashrc && \
-    useradd -u "${MAMBA_USER_ID}" -ms /bin/bash -U "${MAMBA_USER}" && \
-    groupmod -g "${MAMBA_USER_GID}" "${MAMBA_USER}" && \
+    groupadd -g "${MAMBA_USER_GID}" "${MAMBA_USER}" && \
+    useradd -u "${MAMBA_USER_ID}" -g "${MAMBA_USER_GID}" -ms /bin/bash "${MAMBA_USER}" && \
     echo "${MAMBA_USER}" > "/etc/arg_mamba_user" && \
     mkdir -p "$MAMBA_ROOT_PREFIX" && \
     chmod -R a+rwx "$MAMBA_ROOT_PREFIX" "/home" "/etc/arg_mamba_user" && \

--- a/README.md
+++ b/README.md
@@ -176,17 +176,19 @@ The default username is stored in the environment variable `MAMBA_USER`, and is 
 
 There are two supported methods for changing the default username to something other than `mambauser`:
 
-1. If rebuilding this image from scratch, the default username `mambauser` can be adjusted by passing `--build-arg MAMBA_USER=new-username` to the `docker build` command.
+1. If rebuilding this image from scratch, the default username `mambauser` can be adjusted by passing `--build-arg MAMBA_USER=new-username` to the `docker build` command. User id and group id can be adjusted similarly by passing `--build-arg MAMBA_USER_ID=new-id --build-arg MAMBA_USER_GID=new-gid`
 
 2. When building an image `FROM` an existing micromamba image,
 
     ```Dockerfile
     FROM mambaorg/micromamba:0.21.0
     ARG NEW_MAMBA_USER=new-username
+    ARG NEW_MAMBA_USER_ID=1000
+    ARG NEW_MAMBA_USER_GID=1000
     USER root
     RUN usermod "--login=${NEW_MAMBA_USER}" "--home=/home/${MAMBA_USER}" \
-            --move-home "${MAMBA_USER}" && \
-        groupmod "--new-name=${NEW_MAMBA_USER}" "${MAMBA_USER}" && \
+            --move-home "-u ${NEW_MAMBA_USER_ID}" "${MAMBA_USER}" && \
+        groupmod "--new-name=${NEW_MAMBA_USER}" "-g ${NEW_MAMBA_USER_GID}" "${MAMBA_USER}" && \
         # Update the expected value of MAMBA_USER for the _entrypoint.sh consistency check.
         echo "${NEW_MAMBA_USER}" > "/etc/arg_mamba_user" && \
         :

--- a/test/modify-username.Dockerfile
+++ b/test/modify-username.Dockerfile
@@ -3,10 +3,12 @@ ARG BASE_IMAGE=micromamba:test-debian-bullseye-slim
 FROM $BASE_IMAGE
 
 ARG NEW_MAMBA_USER
+ARG NEW_MAMBA_USER_ID=1000
+ARG NEW_MAMBA_USER_GID=1000
 USER root
 RUN usermod "--login=${NEW_MAMBA_USER}" "--home=/home/${MAMBA_USER}" \
-        --move-home "${MAMBA_USER}" && \
-    groupmod "--new-name=${NEW_MAMBA_USER}" "${MAMBA_USER}" && \
+        --move-home "-u ${NEW_MAMBA_USER_ID}" "${MAMBA_USER}" && \
+    groupmod "--new-name=${NEW_MAMBA_USER}" "-g ${NEW_MAMBA_USER_GID}" "${MAMBA_USER}" && \
     # Update the expected value of MAMBA_USER for the _entrypoint.sh consistency check.
     echo "${NEW_MAMBA_USER}" > "/etc/arg_mamba_user" && \
     :


### PR DESCRIPTION
This adds support for custom user id/gid. Setting custom id is convenient if docker images build with `FROM` are used for code development. This removes troubles with access rights of mounted folders. It also allows to install packages inside the container with non-root id/gid