### PR TITLE
Fix home when modifying username

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ There are two supported methods for changing the default username to something o
     ARG NEW_MAMBA_USER_ID=1000
     ARG NEW_MAMBA_USER_GID=1000
     USER root
-    RUN usermod "--login=${NEW_MAMBA_USER}" "--home=/home/${MAMBA_USER}" \
+    RUN usermod "--login=${NEW_MAMBA_USER}" "--home=/home/${NEW_MAMBA_USER}" \
             --move-home "-u ${NEW_MAMBA_USER_ID}" "${MAMBA_USER}" && \
         groupmod "--new-name=${NEW_MAMBA_USER}" "-g ${NEW_MAMBA_USER_GID}" "${MAMBA_USER}" && \
         # Update the expected value of MAMBA_USER for the _entrypoint.sh consistency check.

--- a/test/modify-username.Dockerfile
+++ b/test/modify-username.Dockerfile
@@ -6,7 +6,7 @@ ARG NEW_MAMBA_USER
 ARG NEW_MAMBA_USER_ID=1000
 ARG NEW_MAMBA_USER_GID=1000
 USER root
-RUN usermod "--login=${NEW_MAMBA_USER}" "--home=/home/${MAMBA_USER}" \
+RUN usermod "--login=${NEW_MAMBA_USER}" "--home=/home/${NEW_MAMBA_USER}" \
         --move-home "-u ${NEW_MAMBA_USER_ID}" "${MAMBA_USER}" && \
     groupmod "--new-name=${NEW_MAMBA_USER}" "-g ${NEW_MAMBA_USER_GID}" "${MAMBA_USER}" && \
     # Update the expected value of MAMBA_USER for the _entrypoint.sh consistency check.

--- a/test/user.bats
+++ b/test/user.bats
@@ -88,7 +88,7 @@ setup() {
 
 # Test that home is moved when modifying the username.
 @test "docker run --rm -e MAMBA_USER=$altered_mamba_user ${MICROMAMBA_IMAGE}-modify-username bash -c \"realpath ~${altered_mamba_user}\"" {
-        run docker run --rm -e MAMBA_USER=$altered_mamba_user ${MICROMAMBA_IMAGE}-modify-username bash -c "realpath ~${altered_mamba_user}"
+        run docker run --rm -e "MAMBA_USER=$altered_mamba_user" "${MICROMAMBA_IMAGE}-modify-username" bash -c "realpath ~${altered_mamba_user}"
         assert_success
         assert_output "/home/$altered_mamba_user"
 }

--- a/test/user.bats
+++ b/test/user.bats
@@ -86,6 +86,13 @@ setup() {
         assert_output "$altered_mamba_user"
 }
 
+# Test that home is moved when modifying the username.
+@test "docker run --rm -e MAMBA_USER=$altered_mamba_user ${MICROMAMBA_IMAGE}-modify-username bash -c \"realpath ~${altered_mamba_user}\"" {
+        run docker run --rm -e MAMBA_USER=$altered_mamba_user ${MICROMAMBA_IMAGE}-modify-username bash -c "realpath ~${altered_mamba_user}"
+        assert_success
+        assert_output "/home/$altered_mamba_user"
+}
+
 # Test that custom mamba user id and group id are set correctly for base image builds.
 @test "docker run --rm ${MICROMAMBA_IMAGE}-modify-user-id-gid-base id" {
         run docker run --rm "${MICROMAMBA_IMAGE}-modify-user-id-gid-base" id


### PR DESCRIPTION
In the `usermod` command, I mistakenly set the destination home directory to the old username instead of the new username.

A failing test has been added, then bugfix so that the test now passes.

Output of test before bugfix:
```text
 ✗ docker run --rm -e MAMBA_USER=MaMbAmIcRo micromamba:test-debian-bullseye-slim-modify-username bash -c "realpath ~MaMbAmIcRo"
   (from function `assert_output' in file test/test_helper/bats-assert/src/assert_output.bash, line 194,
    in test file test/user.bats, line 93)
     `assert_output "/home/$altered_mamba_user"' failed
   
   -- output differs --
   expected : /home/MaMbAmIcRo
   actual   : /home/mambauser
   --
```