### PR TITLE
Cache image layers in GH Actions

### DIFF
--- a/.github/workflows/push_latest.yml
+++ b/.github/workflows/push_latest.yml
@@ -36,5 +36,7 @@ jobs:
           mambaorg/micromamba:git-${{ steps.short_hash.outputs.sha_short }}
           mambaorg/micromamba:${{ steps.get_version.outputs.version }}
           mambaorg/micromamba:latest
+        cache-from: type=registry,ref=mambaorg/micromamba:latest
+        cache-to: type=inline
     - name: Image digest
       run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
We don't seem to be using any cache in our builds. The layers are currently regenerated from scratch on each commit, even when there's no change.

I personally find the documentation on caching really confusing, but if I'm reading this correctly, it might be this simple as my proposed commit. Shall we give it a try and see what happens?

https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md