### PR TITLE
Reference base environment specifically in Quick Start install

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ will install software into this 'base' environment.
     ```Dockerfile
     FROM mambaorg/micromamba:0.23.2
     COPY --chown=$MAMBA_USER:$MAMBA_USER env.yaml /tmp/env.yaml
-    RUN micromamba install -y -f /tmp/env.yaml && \
+    RUN micromamba install -y -n base -f /tmp/env.yaml && \
         micromamba clean --all --yes
     ```
 

--- a/examples/yaml_spec/Dockerfile
+++ b/examples/yaml_spec/Dockerfile
@@ -1,4 +1,4 @@
 FROM mambaorg/micromamba:0.23.2
 COPY --chown=$MAMBA_USER:$MAMBA_USER env.yaml /tmp/env.yaml
-RUN micromamba install -y -f /tmp/env.yaml && \
+RUN micromamba install -y -n base -f /tmp/env.yaml && \
     micromamba clean --all --yes


### PR DESCRIPTION
A few users have been tripped up when trying to install dependencies from environment files with specific environment names, which haven't been created.

https://github.com/mamba-org/micromamba-docker/issues/136
https://github.com/mamba-org/micromamba-docker/issues/151

This tripped me up for a minute as well. My workflow is pretty much always to have an environment.yml file with a non-base `name` for local usage, but to install that environment as the `base` environment when creating a portable Docker image using micromamba. I suspect there are others out there doing the same.

Adding `-n base` to the quick start install instructions both clarifies that we're installing to the base environment, and also allows installing into the base environment from environment files with embedded names by overriding the name.