### PR TITLE
Add support for multiple base images

### DIFF
--- a/.github/workflows/push_latest.yml
+++ b/.github/workflows/push_latest.yml
@@ -4,12 +4,22 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - main
+      - 'main'
+    tags:
+      - 'v*'
+
+env:
+  LATEST_DEBIAN: 'bullseye'
+  DEFAULT_SIZE: 'slim'
 
 jobs:
   build_docker_image_and_push:
     if: github.repository == 'mamba-org/micromamba-docker'
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image: ['bullseye', 'buster']
+        size: ['slim', '']
     steps:
     - name: Checkout source
       uses: actions/checkout@230611dbd0eb52da1e1f4f7bc8bb0c3a339fc8b7
@@ -19,7 +29,43 @@ jobs:
     - name: Get micromamba version
       id: get_version
       run: echo "::set-output name=version::$(grep '^ARG VERSION=' Dockerfile  | cut -d= -f2)"
-    - name: Set up Docker Buildx
+    - name: Set image variables
+      id: set_image_variables
+      env:
+        IMAGE: ${{ matrix.image }}
+        SIZE: ${{ matrix.size }}
+      run: |
+        echo "::set-output name=image::debian:${IMAGE}${SIZE:+-$SIZE}"
+        echo "::set-output name=tag::${IMAGE}${SIZE:+-$SIZE}"
+        echo "::set-output name=is_default::$([ "$IMAGE" = "$LATEST_DEBIAN" ] && [ "$SIZE" = "$DEFAULT_SIZE" ] && echo true || echo false)"
+    - name: Get docker metadata
+      id: get_metadata
+      uses: docker/metadata-action@8d56fe93cf3fd680736a906389438c1ed74d75f7
+      with:
+        images: mambaorg/micromamba
+        flavor: latest=false
+        # latest
+        # base_image
+        # major.minor.patch
+        # major.minor
+        # major
+        # major.minor.patch-base_image
+        # major.minor-base_image
+        # major-base_image
+        # git-commit-base_image
+        # git-commit 
+        tags: |
+            type=raw,value=latest,priority=1000,enable=${{ steps.set_image_variables.outputs.is_default }}
+            type=raw,value=${{ steps.set_image_variables.outputs.tag }},priority=900
+            type=semver,pattern={{version}},enable=${{ steps.set_image_variables.outputs.is_default }},value=${{ steps.get_version.outputs.version }},priority=800
+            type=semver,pattern={{major}}.{{minor}},enable=${{ steps.set_image_variables.outputs.is_default }},value=${{ steps.get_version.outputs.version }},priority=700
+            type=semver,pattern={{major}},enable=${{ steps.set_image_variables.outputs.is_default }},value=${{ steps.get_version.outputs.version }},priority=600
+            type=semver,pattern={{version}}-${{ steps.set_image_variables.outputs.tag }},value=${{ steps.get_version.outputs.version }},priority=500
+            type=semver,pattern={{major}}.{{minor}}-${{ steps.set_image_variables.outputs.tag}},value=${{ steps.get_version.outputs.version }},priority=400
+            type=semver,pattern={{major}}-${{ steps.set_image_variables.outputs.tag}},value=${{ steps.get_version.outputs.version }},priority=300
+            type=sha,prefix=git-,suffix=-${{ steps.set_image_variables.outputs.tag }},priority=200
+            type=sha,prefix=git-,enable=${{ steps.set_image_variables.outputs.is_default }},priority=100
+    - name: Setup docker buildx
       uses: docker/setup-buildx-action@79abd3f86f79a9d68a23c75a09a9a85889262adf
     - name: Login to DockerHub
       uses: docker/login-action@17f28ab24d0d2832d5ff23a1409bbfc373ebcb96
@@ -32,10 +78,10 @@ jobs:
       with:
         platforms: linux/amd64,linux/arm64,linux/ppc64le
         push: true
-        tags: |
-          mambaorg/micromamba:git-${{ steps.short_hash.outputs.sha_short }}
-          mambaorg/micromamba:${{ steps.get_version.outputs.version }}
-          mambaorg/micromamba:latest
+        build-args: |
+          BASE_IMAGE=${{ steps.set_image_variables.outputs.image }}
+        tags: ${{ steps.get_metadata.outputs.tags }}
+        labels: ${{ steps.get_metadata.outputs.labels}}
         cache-from: type=registry,ref=mambaorg/micromamba:latest
         cache-to: type=inline
     - name: Image digest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+5 June 2022
+========================
+
+- Build images from all Debian releases that have not yet reached end of life
+- Build images from both slim and non-slim Debian images
+- Revamp tagging to support multiple base images
+
 13 January 2022
 ========================
 

--- a/README.md
+++ b/README.md
@@ -15,17 +15,17 @@ future (see [road map](#road-map)).
 
 ### Tags
 
-When a commit is pushed to the `main` branch of
-[mamba-org/micromamba-docker](https://github.com/mamba-org/micromamba-docker/)
-new docker images are built and pushed to Dockerhub. Each image is tagged with
-the version of `micromamba` it contains and these tags will start with a
-number. Images are also tagged with `git-<HASH>` where `<HASH>` is the first
-7 characters of the git commit hash from the
-[mamba-org/micromamba-docker](https://github.com/mamba-org/micromamba-docker/)
-git repository.
+The set of tags includes permutations of:
+ - base image name (Debian code name, such as `bullseye`, plus `-slim` if derived from a Debian `slim` image)
+ - full or partial version numbers corresponding the `micromamba` version within the image
+ - git commit hashes (`git-<HASH>`, where `<HASH>` is the first 7 characters of the git commit hash in [mamba-org/micromamba-docker](https://github.com/mamba-org/micromamba-docker/))
 
-For reproducible image builds, best practice is for Dockerfile `FROM`
-commands to reference the image's sha256 digest and not use tags.
+The tag `latest` is based on the `slim` image of the most recent Debian release, currently `bullseye-slim`.
+
+Tags that do not contain `git` are rolling tags, meaning these tags get reassigned to new images each time these images are built. 
+
+To reproducibly build images derived from these `micromamba` images, the best practice is for the Dockerfile `FROM`
+command to reference the image's sha256 digest and not use tags.
 
 ## Quick start
 
@@ -281,12 +281,11 @@ available.
 
 ### Road map
 
-The current road map for expanding the number of base images is as follows:
+The current road map for expanding the number of base images and supported shells is as follows:
 
-1. Add all releases of debian slim that have not yet reached LTS end of life (ie, bullseye, buster, stretch)
-1. Add the non-slim debian image
-1. Add other debian based distributions that have community interest (such as Ubuntu)
-1. Add non-debian based distributions that have community interest
+1. Add other Debian based distributions that have community interest (such as Ubuntu)
+1. Add non-Debian based distributions that have community interest
+1. Add support for non-`bash` shells based on community interest
 
 The build and test infrastructure will need to be altered to support additional
 base images such that automated test and build occur for all images produced.


### PR DESCRIPTION
Build images from all Debian releases that have not yet reached end of life
Build images from both slim and non-slim Debian images
Revamp tagging to support multiple base images