### PR TITLE
Activate Conda and Mamba if possible

### DIFF
--- a/_activate_current_env.sh
+++ b/_activate_current_env.sh
@@ -6,10 +6,10 @@ if [[ "${MAMBA_SKIP_ACTIVATE}" == "1" ]]; then
   return
 fi
 
-# Initialize the current shell
+# Initialize Micromamba for the current shell
 eval "$("${MAMBA_EXE}" shell hook --shell=bash)"
 
-# Try to initialize Conda in case it is installed.
+# Attempt to initialize Conda (might not be installed)
 __conda_setup="$('conda' 'shell.bash' 'hook' 2> /dev/null)" || true
 if [ ! -z "${__conda_setup}" ]; then
     eval "$__conda_setup"
@@ -20,7 +20,7 @@ else
 fi
 unset __conda_setup
 
-# Initialize Mamba in case it is on the path.
+# Attempt to initialize Mamba (might not be installed)
 if [ -f "${CONDA_PREFIX}/etc/profile.d/mamba.sh" ]; then
     . "${CONDA_PREFIX}/etc/profile.d/mamba.sh"
 fi

--- a/_activate_current_env.sh
+++ b/_activate_current_env.sh
@@ -9,6 +9,22 @@ fi
 # Initialize the current shell
 eval "$("${MAMBA_EXE}" shell hook --shell=bash)"
 
+# Try to initialize Conda in case it is installed.
+__conda_setup="$('conda' 'shell.bash' 'hook' 2> /dev/null)" || true
+if [ ! -z "${__conda_setup}" ]; then
+    eval "$__conda_setup"
+else
+    if [ -f "${CONDA_PREFIX}/etc/profile.d/conda.sh" ]; then
+        . "${CONDA_PREFIX}/etc/profile.d/conda.sh"
+    fi
+fi
+unset __conda_setup
+
+# Initialize Mamba in case it is on the path.
+if [ -f "${CONDA_PREFIX}/etc/profile.d/mamba.sh" ]; then
+    . "${CONDA_PREFIX}/etc/profile.d/mamba.sh"
+fi
+
 # For robustness, try all possible activate commands.
 conda activate "${ENV_NAME}" 2>/dev/null \
   || mamba activate "${ENV_NAME}" 2>/dev/null \

--- a/_activate_current_env.sh
+++ b/_activate_current_env.sh
@@ -14,15 +14,15 @@ __conda_setup="$('conda' 'shell.bash' 'hook' 2> /dev/null)" || true
 if [ ! -z "${__conda_setup}" ]; then
     eval "$__conda_setup"
 else
-    if [ -f "${CONDA_PREFIX}/etc/profile.d/conda.sh" ]; then
-        . "${CONDA_PREFIX}/etc/profile.d/conda.sh"
+    if [ -f "${MAMBA_ROOT_PREFIX}/etc/profile.d/conda.sh" ]; then
+        . "${MAMBA_ROOT_PREFIX}/etc/profile.d/conda.sh"
     fi
 fi
 unset __conda_setup
 
 # Attempt to initialize Mamba (might not be installed)
-if [ -f "${CONDA_PREFIX}/etc/profile.d/mamba.sh" ]; then
-    . "${CONDA_PREFIX}/etc/profile.d/mamba.sh"
+if [ -f "${MAMBA_ROOT_PREFIX}/etc/profile.d/mamba.sh" ]; then
+    . "${MAMBA_ROOT_PREFIX}/etc/profile.d/mamba.sh"
 fi
 
 # For robustness, try all possible activate commands.

--- a/test/conda-mamba-activate.Dockerfile
+++ b/test/conda-mamba-activate.Dockerfile
@@ -2,11 +2,9 @@ ARG BASE_IMAGE=micromamba:test-debian-bullseye-slim
 
 FROM $BASE_IMAGE
 
-ARG MAMBA_DOCKERFILE_ACTIVATE=1
-RUN micromamba install -y -c conda-forge conda mamba
+RUN micromamba install --yes --name base --channel conda-forge \
+      conda \
+      mamba && \
+    micromamba clean --all --yes
 
-# Test conda init
-RUN bash -c "conda init && bash -c 'conda activate base'"
-
-# Test mamba init
-RUN bash -c "mamba init && bash -c 'mamba activate base'"
+ENV PATH=/opt/conda/bin:$PATH

--- a/test/conda-mamba-activate.Dockerfile
+++ b/test/conda-mamba-activate.Dockerfile
@@ -6,5 +6,3 @@ RUN micromamba install --yes --name base --channel conda-forge \
       conda \
       mamba && \
     micromamba clean --all --yes
-
-ENV PATH=/opt/conda/bin:$PATH

--- a/test/conda-mamba-activate.Dockerfile
+++ b/test/conda-mamba-activate.Dockerfile
@@ -1,0 +1,12 @@
+ARG BASE_IMAGE=micromamba:test-debian-bullseye-slim
+
+FROM $BASE_IMAGE
+
+ARG MAMBA_DOCKERFILE_ACTIVATE=1
+RUN micromamba install -y -c conda-forge conda mamba
+
+# Test conda init
+RUN bash -c "conda init && bash -c 'conda activate base'"
+
+# Test mamba init
+RUN bash -c "mamba init && bash -c 'mamba activate base'"

--- a/test/conda-mamba-activate.bats
+++ b/test/conda-mamba-activate.bats
@@ -13,7 +13,7 @@ setup() {
     _common_setup
 }
 
-@test "docker run --rm \"${MICROMAMBA_IMAGE}-conda-mamba-activate\" /bin/bash -c 'conda activate base && mamba activate base'" {
+@test "'docker run --rm -it \"${MICROMAMBA_IMAGE}-conda-mamba-activate\"' with 'conda activate base && mamba activate base; exit'" {
     input="conda activate base && mamba activate base; exit"
     echo -e $input | faketty \
         docker run --rm -it "${MICROMAMBA_IMAGE}-conda-mamba-activate"

--- a/test/conda-mamba-activate.bats
+++ b/test/conda-mamba-activate.bats
@@ -18,3 +18,8 @@ setup() {
     echo -e $input | faketty \
         docker run --rm -it "${MICROMAMBA_IMAGE}-conda-mamba-activate"
 }
+
+@test "docker run --rm -it \"${MICROMAMBA_IMAGE}-conda-mamba-activate\" /bin/bash -i -c 'conda activate base && mamba activate base'" {
+    run docker run --rm -it "${MICROMAMBA_IMAGE}-conda-mamba-activate" /bin/bash -i -c 'conda activate base && mamba activate base'
+    assert_output ""
+}

--- a/test/conda-mamba-activate.bats
+++ b/test/conda-mamba-activate.bats
@@ -13,7 +13,7 @@ setup() {
     _common_setup
 }
 
-@test "RUN python -c \"import os; os.system('touch foobar')\"" {
-    run docker run --rm "${MICROMAMBA_IMAGE}-conda-mamba-activate" ls -1 foobar
-    assert_output 'foobar'
+@test "docker run --rm \"${MICROMAMBA_IMAGE}-conda-mamba-activate\" /bin/bash -c 'conda activate base && mamba activate base'" {
+    run docker run --rm "${MICROMAMBA_IMAGE}-conda-mamba-activate" \
+        /bin/bash -c 'conda activate base && mamba activate base'
 }

--- a/test/conda-mamba-activate.bats
+++ b/test/conda-mamba-activate.bats
@@ -1,0 +1,19 @@
+setup_file() {
+    load 'test_helper/common-setup'
+    _common_setup
+    docker build --quiet \
+                 "--build-arg=BASE_IMAGE=${MICROMAMBA_IMAGE}" \
+                 "--tag=${MICROMAMBA_IMAGE}-conda-mamba-activate" \
+		 "--file=${PROJECT_ROOT}/test/conda-mamba-activate.Dockerfile" \
+		 "${PROJECT_ROOT}/test" > /dev/null
+}
+
+setup() {
+    load 'test_helper/common-setup'
+    _common_setup
+}
+
+@test "RUN python -c \"import os; os.system('touch foobar')\"" {
+    run docker run --rm "${MICROMAMBA_IMAGE}-conda-mamba-activate" ls -1 foobar
+    assert_output 'foobar'
+}

--- a/test/conda-mamba-activate.bats
+++ b/test/conda-mamba-activate.bats
@@ -14,6 +14,7 @@ setup() {
 }
 
 @test "docker run --rm \"${MICROMAMBA_IMAGE}-conda-mamba-activate\" /bin/bash -c 'conda activate base && mamba activate base'" {
-    run docker run --rm "${MICROMAMBA_IMAGE}-conda-mamba-activate" \
-        /bin/bash -c 'conda activate base && mamba activate base'
+    input="conda activate base && mamba activate base"
+    echo -e $input | faketty \
+        docker run --rm -it "${MICROMAMBA_IMAGE}-conda-mamba-activate"
 }

--- a/test/conda-mamba-activate.bats
+++ b/test/conda-mamba-activate.bats
@@ -14,7 +14,7 @@ setup() {
 }
 
 @test "docker run --rm \"${MICROMAMBA_IMAGE}-conda-mamba-activate\" /bin/bash -c 'conda activate base && mamba activate base'" {
-    input="conda activate base && mamba activate base"
+    input="conda activate base && mamba activate base; exit"
     echo -e $input | faketty \
         docker run --rm -it "${MICROMAMBA_IMAGE}-conda-mamba-activate"
 }

--- a/test/conda-mamba-activate.bats
+++ b/test/conda-mamba-activate.bats
@@ -18,8 +18,3 @@ setup() {
     echo -e $input | faketty \
         docker run --rm -it "${MICROMAMBA_IMAGE}-conda-mamba-activate"
 }
-
-@test "docker run --rm -it \"${MICROMAMBA_IMAGE}-conda-mamba-activate\" /bin/bash -i -c 'conda activate base && mamba activate base'" {
-    run docker run --rm -it "${MICROMAMBA_IMAGE}-conda-mamba-activate" /bin/bash -i -c 'conda activate base && mamba activate base'
-    assert_output ""
-}


### PR DESCRIPTION
Currently we automatically initialize Micromamba. However, when they are installed, we do not automatically initialize Conda or Mamba. Since these tools are so closely related, it seems natural to me that we could extend the activation logic.

This resolves the following error messages.

```bash
$ docker run --rm -i mambaorg/micromamba
(base) mambauser@c044080d3465:/tmp$ micromamba install -y -c conda-forge conda
(base) mambauser@c044080d3465:/tmp$ bash
(base) mambauser@c044080d3465:/tmp$ conda activate base
...
CommandNotFoundError: Your shell has not been properly configured to use 'conda activate'.
To initialize your shell, run

    $ conda init <SHELL_NAME>

Currently supported shells are:
  - bash
  - fish
  - tcsh
  - xonsh
  - zsh
  - powershell

See 'conda init --help' for more information and options.

IMPORTANT: You may need to close and restart your shell after running 'conda init'.
```

and similarly for Mamba

```bash
$ docker run --rm -i mambaorg/micromamba
(base) mambauser@c044080d3465:/tmp$ micromamba install -y -c conda-forge mamba
(base) mambauser@c044080d3465:/tmp$ bash
(base) mambauser@c044080d3465:/tmp$ mamba activate base
Run 'mamba init' to be able to run mamba activate/deactivate
and start a new shell session. Or use conda to activate/deactivate.
```

Assuming there are no objections, I'll provide tests at some point.