### PR TITLE
Add CUDA images for cuda 11.6 and 11.3 for Pytorch 1.11 and 1.12

### DIFF
--- a/.github/workflows/push_latest.yml
+++ b/.github/workflows/push_latest.yml
@@ -26,12 +26,12 @@ jobs:
          - ubuntu:impish
          - ubuntu:focal
          - ubuntu:bionic
-         - nvidia/cuda:11.7.0-runtime-ubuntu22.04
-         - nvidia/cuda:11.7.0-runtime-ubuntu20.04
-         - nvidia/cuda:11.6.2-runtime-ubuntu20.04
-         - nvidia/cuda:11.6.2-runtime-ubuntu18.04      
-         - nvidia/cuda:11.3.1-runtime-ubuntu20.04       
-         - nvidia/cuda:11.3.1-runtime-ubuntu18.04       
+         - nvidia/cuda:11.7.0-base-ubuntu22.04
+         - nvidia/cuda:11.7.0-base-ubuntu20.04
+         - nvidia/cuda:11.6.2-base-ubuntu20.04
+         - nvidia/cuda:11.6.2-base-ubuntu18.04      
+         - nvidia/cuda:11.3.1-base-ubuntu20.04       
+         - nvidia/cuda:11.3.1-base-ubuntu18.04       
 
     steps:
     - name: Install GNU parallel

--- a/.github/workflows/push_latest.yml
+++ b/.github/workflows/push_latest.yml
@@ -29,10 +29,9 @@ jobs:
          - nvidia/cuda:11.7.0-base-ubuntu22.04
          - nvidia/cuda:11.7.0-base-ubuntu20.04
          - nvidia/cuda:11.6.2-base-ubuntu20.04
-         - nvidia/cuda:11.6.2-base-ubuntu18.04      
-         - nvidia/cuda:11.3.1-base-ubuntu20.04       
-         - nvidia/cuda:11.3.1-base-ubuntu18.04       
-
+         - nvidia/cuda:11.6.2-base-ubuntu18.04
+         - nvidia/cuda:11.3.1-base-ubuntu20.04
+         - nvidia/cuda:11.3.1-base-ubuntu18.04
     steps:
     - name: Install GNU parallel
       run: sudo apt-get install --no-install-recommends -y parallel

--- a/.github/workflows/push_latest.yml
+++ b/.github/workflows/push_latest.yml
@@ -26,8 +26,13 @@ jobs:
          - ubuntu:impish
          - ubuntu:focal
          - ubuntu:bionic
-         - nvidia/cuda:11.7.0-base-ubuntu22.04
-         - nvidia/cuda:11.7.0-base-ubuntu20.04
+         - nvidia/cuda:11.7.0-runtime-ubuntu22.04
+         - nvidia/cuda:11.7.0-runtime-ubuntu20.04
+         - nvidia/cuda:11.6.2-runtime-ubuntu20.04
+         - nvidia/cuda:11.6.2-runtime-ubuntu18.04      
+         - nvidia/cuda:11.3.1-runtime-ubuntu20.04       
+         - nvidia/cuda:11.3.1-runtime-ubuntu18.04       
+
     steps:
     - name: Install GNU parallel
       run: sudo apt-get install --no-install-recommends -y parallel


### PR DESCRIPTION
# What does this PR do? 

This PR adds cuda images with the `runtime` for cuda version 11.7, 11.6 and 11.3 with the latest available ubuntu versions. 
Why 11.6 and 11.3? Since Pytorch 1.12 is compiled for cuda 11.6 & 11.3 and Pytorch 1.11 for cuda 11.3


> Three flavors of images are provided:
> * base: Includes the CUDA runtime (cudart)
> * runtime: Builds on the base and includes the [CUDA math libraries](https://developer.nvidia.com/gpu-accelerated-libraries), and [NCCL](https://developer.nvidia.com/nccl). A runtime image that also includes [cuDNN](https://developer.nvidia.com/cudnn) is available.

related to #179 