### PR TITLE
Add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+__pycache__
+.nox
+.pytest_cache
+.mypy_cache
+test/bats


### PR DESCRIPTION
This should speed up the tests which use `docker build`, at least when running locally.