### PR TITLE
readme — correction of lockfile generation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ micromamba:
 ```bash
 docker run -it --rm -v $(pwd):/tmp mambaorg/micromamba:1.3.1 \
    /bin/bash -c "micromamba create --yes --name new_env --file env.yaml && \
-                 micromamba env export --name new_env --explicit > env.lock"
+                 micromamba list --name new_env --explicit > env.lock"
 ```
 
 The lockfile can then be used to install into the pre-existing `base` conda


### PR DESCRIPTION
I suppose, these instructions were meant to say `list`, instead of `env export`.
Please check, if this change is correct.