### PR TITLE
feat: add Debian Bookworm base images

### DIFF
--- a/.github/workflows/push_latest.yml
+++ b/.github/workflows/push_latest.yml
@@ -18,6 +18,8 @@ jobs:
     strategy:
       matrix:
         image:
+         - debian:bookworm-slim
+         - debian:bookworm
          - debian:bullseye-slim
          - debian:bullseye
          - ubuntu:kinetic


### PR DESCRIPTION
Bookworm is the stable Debian release since 2023/06/10, while Bullseye is now oldstable.