### PR TITLE
use the new domain for retrieving micromamba

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ARG TARGETARCH
 RUN test "$TARGETARCH" = 'amd64' && export ARCH='64'; \
     test "$TARGETARCH" = 'arm64' && export ARCH='aarch64'; \
     test "$TARGETARCH" = 'ppc64le' && export ARCH='ppc64le'; \
-    curl -L "https://micromamba.snakepit.net/api/micromamba/linux-${ARCH}/${VERSION}" | \
+    curl -L "https://micro.mamba.pm/api/micromamba/linux-${ARCH}/${VERSION}" | \
     tar -xj -C "/tmp" "bin/micromamba"
 
 FROM $BASE_IMAGE


### PR DESCRIPTION
Hi, we've actually switched a long time ago to the `micro.mamba.pm` domain because some people were a bit offended with the `snakepit` idea :)

At some point the snakepit domain might retire, so I thought it would be good to change it.