### PR TITLE
Install netbase package in Debian based builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN if grep -q '^ID=alpine$' /etc/os-release; then \
         bzip2 \
         ca-certificates \
         curl \
+        netbase \
       && rm -rf /var/lib/apt /var/lib/dpkg /var/lib/cache /var/lib/log; \
    fi
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]


### PR DESCRIPTION
[netbase](https://packages.debian.org/bookworm/netbase) is a tiny (~30kB installed) package providing some core TCP/IP files. It's somehow not included in `debian:bookworm-slim` which can lead to some unexpected errors when trying to use micromamba-docker based images (example: eventlet crashes with `socket.error: protocol not found` if `netbase` is not installed).

https://github.com/eventlet/eventlet/issues/370