### PR TITLE
docs: replace docs that were accidently deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 This change log covers changes to the docker image and does not include
 [changes to the micromamba program](https://github.com/mamba-org/mamba/blob/main/CHANGELOG.md).
 
+## 12 Sept 2023
+
+- Restore documentation that was accidently lost in transition to readthedocs.io
+
 ## 5 September 2023
 
 - Updated to micromamba version 1.5.1

--- a/docs/quick_start.rst
+++ b/docs/quick_start.rst
@@ -42,3 +42,73 @@ include ``python``.
 
       $ docker run -it --rm my_app python --version
       3.9.1
+
+Running commands in Dockerfile within the conda environment
+-----------------------------------------------------------
+
+While the conda environment is automatically activated for ``docker run ...``
+commands, it is not automatically activated during build. To ``RUN`` a command
+from a conda environment within a Dockerfile, as explained in detail in the
+next two subsections, you *must*:
+
+#. Set ``ARG MAMBA_DOCKERFILE_ACTIVATE=1`` to activate the conda environment
+
+#. Use the 'shell' form of the ``RUN`` command
+
+Activating a conda environment for ``RUN`` commands
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+No conda environment is automatically activated during the execution
+of ``RUN`` commands within a Dockerfile. To have an environment active during
+a ``RUN`` command, you must set ``ARG MAMBA_DOCKERFILE_ACTIVATE=1``. For example:
+
+   .. literalinclude:: ../examples/run_activate/Dockerfile
+
+Use the shell form of ``RUN`` with ``micromamba``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The Dockerfile ``RUN`` command can be invoked either in the 'shell' form:
+
+   .. code-block::
+
+      RUN python -c "import uuid; print(uuid.uuid4())"
+
+or the 'exec' form:
+
+   .. code-block::
+
+      RUN ["python", "-c", "import uuid; print(uuid.uuid4())"]  # DO NOT USE THIS FORM!
+
+You *must* use the 'shell' form of ``RUN`` or the command will not execute in
+the context of a conda environment.
+
+Activating a conda environment for ``ENTRYPOINT`` commands
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The Dockerfile for building the ``mambaorg/micromamba`` image contains:
+
+   .. code-block::
+
+      ENTRYPOINT ["/usr/local/bin/_entrypoint.sh"]
+
+where ``_entrypoint.sh`` activates the conda environment for any programs
+run via ``CMD`` in a Dockerfile or using
+``docker run mambaorg/micromamba my_command`` on the command line.
+If you were to make an image derived from ``mambaorg/micromamba`` with:
+
+   .. code-block::
+
+      ENTRYPOINT ["my_command"]
+
+then you will have removed the conda activation from the ``ENTRYPOINT`` and
+``my_command`` will be executed outside of any conda environment.
+
+If you would like an ``ENTRYPOINT`` command to be executed within an active conda
+environment, then add ``"/usr/local/bin/_entrypoint.sh"`` as the first element
+of the JSON array argument to ``ENTRYPOINT``. For example, if you would like
+for your ``ENTRYPOINT`` command to run ``python`` from a conda environment,
+then you would do:
+
+   .. code-block::
+
+      ENTRYPOINT ["/usr/local/bin/_entrypoint.sh", "python"]

--- a/examples/run_activate/Dockerfile
+++ b/examples/run_activate/Dockerfile
@@ -1,0 +1,6 @@
+FROM mambaorg/micromamba:1.5.1
+COPY --chown=$MAMBA_USER:$MAMBA_USER env.yaml /tmp/env.yaml
+RUN micromamba install --yes --file /tmp/env.yaml && \
+    micromamba clean --all --yes
+ARG MAMBA_DOCKERFILE_ACTIVATE=1  # (otherwise python will not be found)
+RUN python -c 'import uuid; print(uuid.uuid4())' > /tmp/my_uuid

--- a/examples/run_activate/env.yaml
+++ b/examples/run_activate/env.yaml
@@ -1,0 +1,5 @@
+name: base
+channels:
+  - conda-forge
+dependencies:
+  - python=3.11.4

--- a/test/examples.bats
+++ b/test/examples.bats
@@ -63,3 +63,7 @@ test_example() {
 @test "examples/yaml_spec" {
     test_example yaml_spec
 }
+
+@test "examples/run_activate" {
+    test_example run_activate
+}


### PR DESCRIPTION
A section of the documentation lost in the transition to readthedocs.io. This restores the missing content.