### PR TITLE
update micromamba Dockerfile for Singularity runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,9 @@ USER $MAMBA_USER
 
 WORKDIR /tmp
 
+# this will enable singularity/apptainer subcommands exec/shell to find the installation (base env)
+ENV PATH="$MAMBA_ROOT_PREFIX/bin:$PATH"
+
 # for use with 'apptainer shell --shell /usr/local/bin/_apptainer_shell.sh ...'
 COPY _apptainer_shell.sh /usr/local/bin/_apptainer_shell.sh
 


### PR DESCRIPTION
This update makes sure that `_activate_current_env.sh` is also executed when running containers with Singularity.

One caveat: at this stage I have only updated the Dockefile and nothing else. Are other updates required? e.g. docs or unit tests?