### PR TITLE
Add nvidia/cuda:11.2.2-base-ubuntu20.04

### DIFF
--- a/.github/workflows/push_latest.yml
+++ b/.github/workflows/push_latest.yml
@@ -40,6 +40,7 @@ jobs:
          - nvidia/cuda:11.6.2-base-ubuntu20.04
          - nvidia/cuda:11.3.1-base-ubuntu20.04
          - nvidia/cuda:11.4.3-base-ubuntu20.04
+         - nvidia/cuda:11.2.2-base-ubuntu20.04
     steps:
     - name: Install GNU parallel, shellcheck, and apptainer
       run: |


### PR DESCRIPTION
Some packages like Qiskit Aer (https://qiskit.org/ecosystem/aer/getting_started.html) only support CUDA 11.2 unfortunately. It would be great if we can support this too with `micromamba-docker`.