### PR TITLE
fix: improved check_version.py error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 This change log covers changes to the docker image and does not include
 [changes to the micromamba program](https://github.com/mamba-org/mamba/blob/main/CHANGELOG.md).
 
+## 21 December 2023
+
+- Improved error handling in `check_version.py`
+
 ## 14 December 2023
 
 - Updated to micromamba version 1.5.5

--- a/check_version.py
+++ b/check_version.py
@@ -23,7 +23,10 @@ ArchVersions = Dict[str, List[VersionInfo]]
 
 def to_version(ver: str) -> VersionInfo:
     """Converts str to VersionInfo"""
-    return VersionInfo.parse(ver)
+    try:
+        return VersionInfo.parse(ver)
+    except ValueError:
+        return VersionInfo.parse("0.0.1")
 
 
 def anaconda_versions(url: str) -> Dict[str, List[VersionInfo]]:


### PR DESCRIPTION
invalid semver strings now convert to 0.0.1