### PR TITLE
ci: revert to ubuntu-22.04 for pipeline runner

### DIFF
--- a/.github/workflows/push_latest.yml
+++ b/.github/workflows/push_latest.yml
@@ -20,7 +20,7 @@ env:
 jobs:
   build_docker_image_and_push:
     if: github.repository == 'mamba-org/micromamba-docker'
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         image:
@@ -247,7 +247,7 @@ jobs:
   update_dockerhub_discription:
     if: github.repository == 'mamba-org/micromamba-docker'
     needs: build_docker_image_and_push
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout source
       uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
@@ -298,7 +298,7 @@ jobs:
   tag_and_release:
     if: github.repository == 'mamba-org/micromamba-docker'
     needs: build_docker_image_and_push
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout source
       uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938


### PR DESCRIPTION
Gets us an older appatainer version that may fix an issue with testing the alpine images.