### PR TITLE
Set CONDA_OVERRIDE_CUDA env var (issue #620)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 This change log covers changes to the docker image and does not include
 [changes to the micromamba program](https://github.com/mamba-org/mamba/blob/main/CHANGELOG.md).
 
+
+## 14 May 2025
+
+- Set `CONDA_OVERRIDE_CUDA` in cuda images
+
 ## 5 May 2025
 
 - Updated to micromamba version 2.1.1

--- a/debian.Dockerfile
+++ b/debian.Dockerfile
@@ -26,6 +26,7 @@ ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
 ENV ENV_NAME="base"
 ENV MAMBA_ROOT_PREFIX="/opt/conda"
 ENV MAMBA_EXE="/bin/micromamba"
+ENV CONDA_OVERRIDE_CUDA=${CUDA_VERSION:-""}
 
 COPY --from=stage1 "${MAMBA_EXE}" "${MAMBA_EXE}"
 COPY --from=stage1 "${CERT_SOURCE}" "${CERT_SOURCE}"


### PR DESCRIPTION
Set the `$CONDA_OVERRIDE_CUDA` env var equal to `$CUDA_VERSION` for Debian/Ubuntu images so that Micromamba resolves the appropriate version of packages which depend on the installed version of CUDA (see issue #620).