### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/push_latest.yml
+++ b/.github/workflows/push_latest.yml
@@ -8,6 +8,9 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: read
+
 env:
   DEFAULT_BASE_IMAGE: 'debian:12-slim'
   LATEST_DEBIAN_BASE_IMAGE: 'debian:12'
@@ -303,6 +306,9 @@ jobs:
     if: github.repository == 'mamba-org/micromamba-docker'
     needs: build_docker_image_and_push
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+      issues: write
     steps:
     - name: Checkout source
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683


### PR DESCRIPTION
Potential fix for [https://github.com/mamba-org/micromamba-docker/security/code-scanning/12](https://github.com/mamba-org/micromamba-docker/security/code-scanning/12)

To fix the issue, we will add a `permissions` block to the workflow. This block will explicitly define the minimal permissions required for the workflow to function correctly. At the root level, we will set `contents: read` as the default permission for all jobs. For the `tag_and_release` job, which requires additional permissions to create tags and releases, we will override the default permissions and grant `contents: write` and `issues: write`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
