### PR TITLE
Add cuda 12.9.0 base images

### DIFF
--- a/.github/workflows/push_latest.yml
+++ b/.github/workflows/push_latest.yml
@@ -15,7 +15,7 @@ env:
   LATEST_UBUNTU_BASE_IMAGE: 'ubuntu:25.04'
   LATEST_AMAZON_BASE_IMAGE: 'public.ecr.aws/amazonlinux/amazonlinux:2023'
   LATEST_ALPINE_BASE_IMAGE: 'frolvlad/alpine-glibc:alpine-3.21'
-  LATEST_CUDA_BASE_IMAGE: 'nvidia/cuda:12.8.1-base-ubuntu24.04'
+  LATEST_CUDA_BASE_IMAGE: 'nvidia/cuda:12.9.0-base-ubuntu24.04'
 
 jobs:
   build_docker_image_and_push:
@@ -37,6 +37,9 @@ jobs:
          - frolvlad/alpine-glibc:alpine-3.19
          - frolvlad/alpine-glibc:alpine-3.18
          - public.ecr.aws/amazonlinux/amazonlinux:2023
+         - nvidia/cuda:12.9.0-base-ubuntu24.04
+         - nvidia/cuda:12.9.0-base-ubuntu22.04
+         - nvidia/cuda:12.9.0-base-ubuntu20.04
          - nvidia/cuda:12.8.1-base-ubuntu24.04
          - nvidia/cuda:12.8.1-base-ubuntu22.04
          - nvidia/cuda:12.8.1-base-ubuntu20.04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This change log covers changes to the docker image and does not include
 [changes to the micromamba program](https://github.com/mamba-org/mamba/blob/main/CHANGELOG.md).
 
 
+## 28 May 2025
+
+- Add image based on `nvidia/cuda:12.9.0-base-ubuntu24.04`
+- Add image based on `nvidia/cuda:12.9.0-base-ubuntu22.04`
+- Add image based on `nvidia/cuda:12.9.0-base-ubuntu20.04`
+
 ## 14 May 2025
 
 - Set `CONDA_OVERRIDE_CUDA` in cuda images


### PR DESCRIPTION
Adding base images for CUDA 12.9.0. Verified they are available, see:
https://hub.docker.com/r/nvidia/cuda/tags?name=12.9.0-base-ubuntu24.04
https://hub.docker.com/r/nvidia/cuda/tags?name=12.9.0-base-ubuntu22.04
https://hub.docker.com/r/nvidia/cuda/tags?name=12.9.0-base-ubuntu20.04